### PR TITLE
add lava mainnet

### DIFF
--- a/chains/mainnet/lava.json
+++ b/chains/mainnet/lava.json
@@ -1,8 +1,8 @@
 {
-    "chain_name": "lava-testnet-2",
+    "chain_name": "lava",
     "coingecko": "lava",
-    "api":["https://us-central1-omakase-explorer.cloudfunctions.net/proxyToSentrylavaTestApi"],
-    "rpc": ["https://us-central1-omakase-explorer.cloudfunctions.net/proxyToSentrylavaTestRpc"],
+    "api":["https://us-central1-omakase-explorer.cloudfunctions.net/proxyToSentrylavaApi"],
+    "rpc": ["https://us-central1-omakase-explorer.cloudfunctions.net/proxyToSentrylavaRpc"],
     "snapshot_provider": "",
     "coin_type": 60,
     "sdk_version": "0.46.10",

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,11 +1,9 @@
 const dymensionFunctions = require("./mainnet/dymension/index");
 const seiFunctions = require("./mainnet/sei/index");
 const lavaFunctions = require("./mainnet/lava/index");
-const lavaTestFunctions = require("./testnet/lava/index");
 
 module.exports = {
   ...dymensionFunctions,
   ...seiFunctions,
   ...lavaFunctions,
-  ...lavaTestFunctions,
 };

--- a/functions/testnet/lava/index.js
+++ b/functions/testnet/lava/index.js
@@ -1,8 +1,0 @@
-const functions = require("firebase-functions");
-const createApp = require("../../common/createApp");
-
-const apiApp = createApp('http://lava-testnet-rpc-nlb-05cbce6b4246dcc2.elb.ap-northeast-1.amazonaws.com:14617');
-const rpcApp = createApp('http://lava-testnet-rpc-nlb-05cbce6b4246dcc2.elb.ap-northeast-1.amazonaws.com:26657');
-
-exports.proxyToSentrylavaTestApi = functions.https.onRequest(apiApp);
-exports.proxyToSentrylavaTestRpc = functions.https.onRequest(rpcApp);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Transitioned the blockchain configuration from testnet to mainnet, enhancing clarity for users.
  - Updated API and RPC endpoints for the mainnet, providing a more straightforward access point for integration.

- **Bug Fixes**
  - Removed deprecated `lavaTestFunctions`, streamlining the module's export structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->